### PR TITLE
Add Takumi Guard registry configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.flatt.tech

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
   }
 }


### PR DESCRIPTION
## 概要

[Takumi Guard](https://flatt.tech/takumi/features/guard) によるサプライチェーン保護を有効化するため、npm のレジストリ設定を追加します。

## 変更内容

- `.npmrc`: パッケージインストール時のレジストリを Takumi のプロキシレジストリ (`https://npm.flatt.tech`) に変更
- `package.json`: `publishConfig.registry` を追加し、公開先は従来通り公式レジストリ (`https://registry.npmjs.org`) を維持

## 背景・目的

- 依存パッケージの取得を Takumi 経由にすることで、悪意ある／脆弱なパッケージの混入を防ぎます。
- 公開 (`npm publish`) は公式 npm レジストリへ行うため、`publishConfig.registry` を明示して切り分けています。