### PR TITLE
Add min-release-age to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+min-release-age=7
 registry=https://npm.flatt.tech


### PR DESCRIPTION
## Summary
- `.npmrc` に `min-release-age=7` を追加し、公開直後の npm パッケージのインストールを抑止する
- 既存の Takumi Guard（`registry=https://npm.flatt.tech`）と合わせてサプライチェーン攻撃への防御を強化する

## Test plan
- [x] `.npmrc` に `min-release-age=7` と `registry=https://npm.flatt.tech` の両方が含まれていること
- [x] `npm ci` / `npm install` がこれまで通り動作すること（npm v11.10+ で `min-release-age` が有効）


Made with [Cursor](https://cursor.com)